### PR TITLE
Se agrega la posibilidad de que los artículos estén cotizados en diferentes monedas 

### DIFF
--- a/Lbl/Articulos/Articulo.cs
+++ b/Lbl/Articulos/Articulo.cs
@@ -282,6 +282,18 @@ namespace Lbl.Articulos
                         }
                 }
 
+                public decimal PvpLocal
+                {
+                        get
+                        {
+                                if (Moneda.Cotizacion > 1)
+                                        return Moneda.Cotizacion * this.Pvp;
+                                else
+                                        return this.Pvp;
+                        }
+                        
+                }
+
                 public DbDateTime FechaPrecio
                 {
                         get
@@ -489,6 +501,18 @@ namespace Lbl.Articulos
                         get
                         {
                                 return this.GetFieldValue<decimal>("pedido");
+                        }
+                }
+
+                public decimal CostoLocal
+                {
+                        get
+                        {
+
+                                if (Moneda.Cotizacion > 1)
+                                        return Moneda.Cotizacion * this.Costo;
+                                else
+                                        return this.Costo;
                         }
                 }
 

--- a/Lbl/Articulos/Articulo.cs
+++ b/Lbl/Articulos/Articulo.cs
@@ -18,6 +18,7 @@ namespace Lbl.Articulos
                 private Lbl.Cajas.Caja m_Caja = null;
                 private ColeccionItem m_ListaItem = null;
                 private Receta m_Receta = null;
+                private Entidades.Moneda m_Moneda = null;
                 public decimal ExistenciasInicial { get; set; }
 
                 //Heredar constructor
@@ -92,6 +93,10 @@ namespace Lbl.Articulos
 
 
 
+                /// <summary>
+                /// Obtiene o establece un texto que representa el tercer código de identificación interna del artículo.
+                /// </summary>
+                [Column(Name = "codigo1")]
                 public string Codigo1
                 {
                         get
@@ -104,6 +109,10 @@ namespace Lbl.Articulos
                         }
                 }
 
+                /// <summary>
+                /// Obtiene o establece un texto que representa el segundo código de identificación interna del artículo.
+                /// </summary>
+                [Column(Name = "codigo2")]
                 public string Codigo2
                 {
                         get
@@ -116,6 +125,10 @@ namespace Lbl.Articulos
                         }
                 }
 
+                /// <summary>
+                /// Obtiene o establece un texto que representa el tercer código de identificación interna del artículo.
+                /// </summary>
+                [Column(Name = "codigo3")]
                 public string Codigo3
                 {
                         get
@@ -128,6 +141,10 @@ namespace Lbl.Articulos
                         }
                 }
 
+                /// <summary>
+                /// Obtiene o establece un texto que representa el cuarto código de identificación interna del artículo.
+                /// </summary>
+                [Column(Name = "codigo4")]
                 public string Codigo4
                 {
                         get
@@ -140,6 +157,10 @@ namespace Lbl.Articulos
                         }
                 }
 
+                /// <summary>
+                /// Obtiene o establece un texto que representa el modelo del artículo.
+                /// </summary>
+                [Column(Name = "modelo")]
                 public string Modelo
                 {
                         get
@@ -152,6 +173,10 @@ namespace Lbl.Articulos
                         }
                 }
 
+                /// <summary>
+                /// Obtiene o establece un texto que representa la serie del artículo.
+                /// </summary>
+                [Column(Name = "serie")]
                 public string Serie
                 {
                         get
@@ -164,6 +189,10 @@ namespace Lbl.Articulos
                         }
                 }
 
+                /// <summary>
+                /// Obtiene o establece un texto que representa la forma en la cual se contabiliza una unidad del artículo.
+                /// </summary>
+                [Column(Name = "unidad_stock")]
                 public string Unidad
                 {
                         get
@@ -197,6 +226,28 @@ namespace Lbl.Articulos
                         set
                         {
                                 Registro["rendimiento"] = value;
+                        }
+                }
+
+                /// <summary>
+                /// Obtiene o establece un el objeto Moneda con el cual se calcula el costo del articulo.
+                /// </summary>
+                [Column(Name = "id_moneda")]
+                public Entidades.Moneda Moneda
+                {
+                        get
+                        {
+                                if (m_Moneda == null && this.GetFieldValue<int>("id_moneda") != 0)
+                                {
+                                        m_Moneda = new Entidades.Moneda(this.Connection, this.GetFieldValue<int>("id_moneda"));
+                                        return m_Moneda;
+                                }
+                                return m_Moneda;
+                        }
+                        set
+                        {
+                                m_Moneda = value;
+                                this.SetFieldValue("id_moneda", value);
                         }
                 }
 
@@ -438,9 +489,12 @@ namespace Lbl.Articulos
                 {
                         if (this.TipoDeArticulo == Articulos.TiposDeArticulo.ProductoCompuesto && this.Receta != null)
                         {
+                                if (Moneda.Cotizacion > 1)
+                                        return Moneda.Cotizacion * Receta.Costo;
                                 return Receta.Costo;
                         } else
-                        {
+                        {       if (Moneda.Cotizacion > 1)
+                                        return Moneda.Cotizacion * this.Costo;
                                 return this.Costo;
                         }
                 }
@@ -859,6 +913,11 @@ namespace Lbl.Articulos
                         else
                                 Comando.ColumnValues.AddWithValue("id_caja", this.Caja.Id);
 
+                        if (this.Moneda == null)
+                                Comando.ColumnValues.AddWithValue("id_moneda", null);
+                        else
+                                Comando.ColumnValues.AddWithValue("id_moneda", this.Moneda.Id);
+
                         Comando.ColumnValues.AddWithValue("modelo", this.Modelo);
                         Comando.ColumnValues.AddWithValue("serie", this.Serie);
                         Comando.ColumnValues.AddWithValue("nombre", this.Nombre);
@@ -871,7 +930,7 @@ namespace Lbl.Articulos
 
                         Comando.ColumnValues.AddWithValue("descripcion", this.Descripcion);
                         Comando.ColumnValues.AddWithValue("descripcion2", this.Descripcion2);
-                        Comando.ColumnValues.AddWithValue("destacado", this.Destacado);
+                        Comando.ColumnValues.AddWithValue("destacado", this.Destacado);                        
                         Comando.ColumnValues.AddWithValue("costo", this.Costo);
 
                         if (this.Margen == null)

--- a/Lbl/Articulos/Articulo.cs
+++ b/Lbl/Articulos/Articulo.cs
@@ -237,12 +237,19 @@ namespace Lbl.Articulos
                 {
                         get
                         {
-                                if (m_Moneda == null && this.GetFieldValue<int>("id_moneda") != 0)
+                                if (this.GetFieldValue<int>("id_moneda") != 0)
                                 {
                                         m_Moneda = new Entidades.Moneda(this.Connection, this.GetFieldValue<int>("id_moneda"));
                                         return m_Moneda;
+                                } else {
+                                        Lbl.Entidades.Pais PaisActual = new Lbl.Entidades.Pais(this.Connection, Lfx.Workspace.Master.CurrentConfig.ReadGlobalSetting<int>("Sistema.Pais", 1));
+                                        if (PaisActual != null)
+                                                m_Moneda = PaisActual.Moneda;
+                                        else
+                                                m_Moneda = new Entidades.Moneda(Lfx.Workspace.Master.MasterConnection, 3);
+                                        return m_Moneda;
                                 }
-                                return m_Moneda;
+                                
                         }
                         set
                         {

--- a/Lbl/Articulos/Articulo.cs
+++ b/Lbl/Articulos/Articulo.cs
@@ -9,8 +9,8 @@ namespace Lbl.Articulos
         [Lbl.Atributos.Nomenclatura(NombreSingular = "Artículo", Grupo = "Artículos")]
         [Lbl.Atributos.Datos(TablaDatos = "articulos", CampoId = "id_articulo", TablaImagenes = "articulos_imagenes")]
         [Lbl.Atributos.Presentacion()]
-	public class Articulo : ElementoDeDatos, IElementoConImagen, Lbl.IEstadosEstandar
-	{
+        public class Articulo : ElementoDeDatos, IElementoConImagen, Lbl.IEstadosEstandar
+        {
                 private Lbl.Articulos.Categoria m_Categoria = null;
                 private Lbl.Personas.Persona m_Proveedor = null;
                 private Lbl.Articulos.Margen m_Margen = null;
@@ -20,12 +20,12 @@ namespace Lbl.Articulos
                 private Receta m_Receta = null;
                 public decimal ExistenciasInicial { get; set; }
 
-		//Heredar constructor
-		public Articulo(Lfx.Data.IConnection dataBase) 
+                //Heredar constructor
+                public Articulo(Lfx.Data.IConnection dataBase)
                         : base(dataBase) { }
 
-		public Articulo(Lfx.Data.IConnection dataBase, int itemId)
-			: base(dataBase, itemId) { }
+                public Articulo(Lfx.Data.IConnection dataBase, int itemId)
+                        : base(dataBase, itemId) { }
 
                 public Articulo(Lfx.Data.IConnection dataBase, Lfx.Data.Row row)
                         : base(dataBase, row) { }
@@ -80,9 +80,11 @@ namespace Lbl.Articulos
                         }
                         set
                         {
-                                if (value == null) {
+                                if (value == null)
+                                {
                                         this.Registro["obs"] = null;
-                                } else {
+                                } else
+                                {
                                         this.Registro["obs"] = value.Trim(new char[] { '\n', '\r', ' ' });
                                 }
                         }
@@ -91,136 +93,136 @@ namespace Lbl.Articulos
 
 
                 public string Codigo1
-		{
-			get
-			{
-				return this.GetFieldValue<string>("codigo1");
-			}
-			set
-			{
-				Registro["codigo1"] = value;
-			}
-		}
+                {
+                        get
+                        {
+                                return this.GetFieldValue<string>("codigo1");
+                        }
+                        set
+                        {
+                                Registro["codigo1"] = value;
+                        }
+                }
 
-		public string Codigo2
-		{
-			get
-			{
-				return this.GetFieldValue<string>("codigo2");
-			}
-			set
-			{
-				Registro["codigo2"] = value;
-			}
-		}
+                public string Codigo2
+                {
+                        get
+                        {
+                                return this.GetFieldValue<string>("codigo2");
+                        }
+                        set
+                        {
+                                Registro["codigo2"] = value;
+                        }
+                }
 
-		public string Codigo3
-		{
-			get
-			{
-				return this.GetFieldValue<string>("codigo3");
-			}
-			set
-			{
-				Registro["codigo3"] = value;
-			}
-		}
+                public string Codigo3
+                {
+                        get
+                        {
+                                return this.GetFieldValue<string>("codigo3");
+                        }
+                        set
+                        {
+                                Registro["codigo3"] = value;
+                        }
+                }
 
-		public string Codigo4
-		{
-			get
-			{
-				return this.GetFieldValue<string>("codigo4");
-			}
-			set
-			{
-				Registro["codigo4"] = value;
-			}
-		}
+                public string Codigo4
+                {
+                        get
+                        {
+                                return this.GetFieldValue<string>("codigo4");
+                        }
+                        set
+                        {
+                                Registro["codigo4"] = value;
+                        }
+                }
 
-		public string Modelo
-		{
-			get
-			{
-				return this.GetFieldValue<string>("modelo");
-			}
-			set
-			{
-				Registro["modelo"] = value;
-			}
-		}
+                public string Modelo
+                {
+                        get
+                        {
+                                return this.GetFieldValue<string>("modelo");
+                        }
+                        set
+                        {
+                                Registro["modelo"] = value;
+                        }
+                }
 
-		public string Serie
-		{
-			get
-			{
-				return this.GetFieldValue<string>("serie");
-			}
-			set
-			{
-				Registro["serie"] = value;
-			}
-		}
+                public string Serie
+                {
+                        get
+                        {
+                                return this.GetFieldValue<string>("serie");
+                        }
+                        set
+                        {
+                                Registro["serie"] = value;
+                        }
+                }
 
-		public string Unidad
-		{
-			get
-			{
-				return this.GetFieldValue<string>("unidad_stock");
-			}
-			set
-			{
-				Registro["unidad_stock"] = value;
-			}
-		}
+                public string Unidad
+                {
+                        get
+                        {
+                                return this.GetFieldValue<string>("unidad_stock");
+                        }
+                        set
+                        {
+                                Registro["unidad_stock"] = value;
+                        }
+                }
 
-		public string UnidadRendimiento
-		{
-			get
-			{
-				return this.GetFieldValue<string>("unidad_rend");
-			}
-			set
-			{
-				Registro["unidad_rend"] = value;
-			}
-		}
+                public string UnidadRendimiento
+                {
+                        get
+                        {
+                                return this.GetFieldValue<string>("unidad_rend");
+                        }
+                        set
+                        {
+                                Registro["unidad_rend"] = value;
+                        }
+                }
 
                 public decimal Rendimiento
-		{
-			get
-			{
-				return this.GetFieldValue<decimal>("rendimiento");
-			}
-			set
-			{
-				Registro["rendimiento"] = value;
-			}
-		}
+                {
+                        get
+                        {
+                                return this.GetFieldValue<decimal>("rendimiento");
+                        }
+                        set
+                        {
+                                Registro["rendimiento"] = value;
+                        }
+                }
 
                 public decimal PuntoDeReposicion
-		{
-			get
-			{
-				return this.GetFieldValue<decimal>("stock_minimo");
-			}
-			set
-			{
-				Registro["stock_minimo"] = value;
-			}
-		}
+                {
+                        get
+                        {
+                                return this.GetFieldValue<decimal>("stock_minimo");
+                        }
+                        set
+                        {
+                                Registro["stock_minimo"] = value;
+                        }
+                }
 
                 public decimal Pvp
-		{
-			get
-			{
-				return this.GetFieldValue<decimal>("pvp");
-			}
-			set
-			{
-				Registro["pvp"] = value;
-			}
-		}
+                {
+                        get
+                        {
+                                return this.GetFieldValue<decimal>("pvp");
+                        }
+                        set
+                        {
+                                Registro["pvp"] = value;
+                        }
+                }
 
                 public DbDateTime FechaPrecio
                 {
@@ -238,77 +240,77 @@ namespace Lbl.Articulos
                         }
                 }
 
-		public string Url
-		{
-			get
-			{
-				return this.GetFieldValue<string>("url");
-			}
-			set
-			{
-				Registro["url"] = value;
-			}
-		}
+                public string Url
+                {
+                        get
+                        {
+                                return this.GetFieldValue<string>("url");
+                        }
+                        set
+                        {
+                                Registro["url"] = value;
+                        }
+                }
 
-		public string Descripcion
-		{
-			get
-			{
-				return this.GetFieldValue<string>("descripcion");
-			}
-			set
-			{
-				Registro["descripcion"] = value;
-			}
-		}
+                public string Descripcion
+                {
+                        get
+                        {
+                                return this.GetFieldValue<string>("descripcion");
+                        }
+                        set
+                        {
+                                Registro["descripcion"] = value;
+                        }
+                }
 
-		public string Descripcion2
-		{
-			get
-			{
-				return this.GetFieldValue<string>("descripcion2");
-			}
-			set
-			{
-				Registro["descripcion2"] = value;
-			}
-		}
+                public string Descripcion2
+                {
+                        get
+                        {
+                                return this.GetFieldValue<string>("descripcion2");
+                        }
+                        set
+                        {
+                                Registro["descripcion2"] = value;
+                        }
+                }
 
-		public Publicacion Publicacion
-		{
-			get
-			{
-				return (Publicacion)this.GetFieldValue<int>("web");
-			}
-			set
-			{
-				Registro["web"] = value;
-			}
-		}
+                public Publicacion Publicacion
+                {
+                        get
+                        {
+                                return (Publicacion)this.GetFieldValue<int>("web");
+                        }
+                        set
+                        {
+                                Registro["web"] = value;
+                        }
+                }
 
-		public bool Destacado
-		{
-			get
-			{
-				return System.Convert.ToBoolean(Registro["destacado"]);
-			}
-			set
-			{
-				Registro["destacado"] = value;
-			}
-		}
+                public bool Destacado
+                {
+                        get
+                        {
+                                return System.Convert.ToBoolean(Registro["destacado"]);
+                        }
+                        set
+                        {
+                                Registro["destacado"] = value;
+                        }
+                }
 
                 public TiposDeArticulo TipoDeArticulo
-		{
-			get
-			{
-				return (TiposDeArticulo)(Registro.Fields["control_stock"].ValueInt);
-			}
-			set
-			{
-				Registro["control_stock"] = (int)value;
-			}
-		}
+                {
+                        get
+                        {
+                                return (TiposDeArticulo)(Registro.Fields["control_stock"].ValueInt);
+                        }
+                        set
+                        {
+                                Registro["control_stock"] = (int)value;
+                        }
+                }
 
 
                 /// <summary>
@@ -372,14 +374,16 @@ namespace Lbl.Articulos
 
                 public Lbl.Impuestos.Alicuota ObtenerAlicuota()
                 {
-                        if (this.Categoria != null) {
+                        if (this.Categoria != null)
+                        {
                                 if (this.Categoria.Alicuota != null)
                                         return this.Categoria.Alicuota;
                                 else if (this.Categoria.Rubro != null && this.Categoria.Rubro.Alicuota != null)
                                         return this.Categoria.Rubro.Alicuota;
                                 else
                                         return Lbl.Sys.Config.Empresa.AlicuotaPredeterminada;
-                        } else {
+                        } else
+                        {
                                 return Lbl.Sys.Config.Empresa.AlicuotaPredeterminada;
                         }
                 }
@@ -388,10 +392,13 @@ namespace Lbl.Articulos
                 {
                         get
                         {
-                                if (m_ListaItem == null) {
+                                if (m_ListaItem == null)
+                                {
                                         m_ListaItem = new ColeccionItem();
-                                        using (System.Data.DataTable TablaListaItem = this.Connection.Select("SELECT id_situacion, serie FROM articulos_series WHERE id_articulo=" + this.Id.ToString())) {
-                                                foreach (System.Data.DataRow RowItem in TablaListaItem.Rows) {
+                                        using (System.Data.DataTable TablaListaItem = this.Connection.Select("SELECT id_situacion, serie FROM articulos_series WHERE id_articulo=" + this.Id.ToString()))
+                                        {
+                                                foreach (System.Data.DataRow RowItem in TablaListaItem.Rows)
+                                                {
                                                         m_ListaItem.Add(new Item(RowItem["serie"].ToString(), new Situacion(this.Connection, System.Convert.ToInt32(RowItem["id_situacion"]))));
                                                 }
                                         }
@@ -405,7 +412,7 @@ namespace Lbl.Articulos
                 /// Las existencias actuales.
                 /// </summary>
                 public decimal Existencias
-		{
+                {
                         get
                         {
                                 if (Lfx.Workspace.Master.SlowLink)
@@ -413,7 +420,7 @@ namespace Lbl.Articulos
                                 else
                                         return this.ObtenerExistencias();
                         }
-		}
+                }
 
 
                 /// <summary>
@@ -429,16 +436,19 @@ namespace Lbl.Articulos
 
                 public decimal ObtenerCosto()
                 {
-                        if (this.TipoDeArticulo == Articulos.TiposDeArticulo.ProductoCompuesto && this.Receta != null) {
+                        if (this.TipoDeArticulo == Articulos.TiposDeArticulo.ProductoCompuesto && this.Receta != null)
+                        {
                                 return Receta.Costo;
-                        } else {
+                        } else
+                        {
                                 return this.Costo;
                         }
                 }
 
                 public decimal ObtenerExistencias()
                 {
-                        switch(this.TipoDeArticulo) {
+                        switch (this.TipoDeArticulo)
+                        {
                                 case Articulos.TiposDeArticulo.Servicio:
                                         return 0;
                                 case Articulos.TiposDeArticulo.ProductoSimple:
@@ -452,8 +462,9 @@ namespace Lbl.Articulos
                 }
 
                 public decimal ObtenerExistencias(Situacion situacion)
-		{
-                        switch (this.TipoDeArticulo) {
+                {
+                        switch (this.TipoDeArticulo)
+                        {
                                 case Articulos.TiposDeArticulo.Servicio:
                                         return 0;
                                 case Articulos.TiposDeArticulo.ProductoSimple:
@@ -461,7 +472,8 @@ namespace Lbl.Articulos
                                 case Articulos.TiposDeArticulo.ProductoCompuesto:
                                         // Calculo el stock según el elemento de la receta que se acabe primero
                                         decimal CantMin = decimal.MaxValue;
-                                        foreach (ItemReceta Itm in this.Receta) {
+                                        foreach (ItemReceta Itm in this.Receta)
+                                        {
                                                 decimal Cant = Itm.Articulo.ObtenerExistencias(situacion) / Itm.Cantidad;
                                                 if (Cant < CantMin)
                                                         CantMin = Cant;
@@ -473,27 +485,31 @@ namespace Lbl.Articulos
                                 default:
                                         throw new Lfx.Types.DomainException("ObtenerExistencias(Situacion): No se pueden calcular las existencias para " + this.TipoDeArticulo.ToString());
                         }
-		}
+                }
 
 
                 public void MoverExistencias(Lbl.Comprobantes.ComprobanteConArticulos comprob, decimal cantidad, string obs, Situacion situacionOrigen, Situacion situacionDestino, Lbl.Articulos.ColeccionDatosSeguimiento seguimiento)
-		{
+                {
                         decimal Saldo;
 
-                        if (this.TipoDeArticulo != Articulos.TiposDeArticulo.Servicio) {
+                        if (this.TipoDeArticulo != Articulos.TiposDeArticulo.Servicio)
+                        {
                                 decimal CantidadEntranteOSaliente = 0;
 
                                 // stock saliente (situación de origen)
-                                if (situacionOrigen != null && situacionOrigen.CuentaExistencias) {
+                                if (situacionOrigen != null && situacionOrigen.CuentaExistencias)
+                                {
                                         int Existe = this.Connection.FieldInt("SELECT COUNT(id_articulo) FROM articulos_stock WHERE id_articulo=" + this.Id.ToString() + " AND id_situacion=" + situacionOrigen.Id.ToString());
-                                        if (Existe == 0) {
+                                        if (Existe == 0)
+                                        {
                                                 // No existen datos de stock para esta situación... la creo
                                                 qGen.Insert InsertarCantidadSituacion = new qGen.Insert("articulos_stock");
                                                 InsertarCantidadSituacion.ColumnValues.AddWithValue("id_articulo", this.Id);
                                                 InsertarCantidadSituacion.ColumnValues.AddWithValue("id_situacion", situacionOrigen.Id);
                                                 InsertarCantidadSituacion.ColumnValues.AddWithValue("cantidad", -cantidad);
                                                 this.Connection.ExecuteNonQuery(InsertarCantidadSituacion);
-                                        } else {
+                                        } else
+                                        {
                                                 // Actualizo el stock en la nueva situación
                                                 qGen.Update ActualizarCantidadSituacion = new qGen.Update("articulos_stock");
                                                 ActualizarCantidadSituacion.ColumnValues.AddWithValue("cantidad", new qGen.SqlExpression(@"""cantidad""-" + Lfx.Types.Formatting.FormatStockSql(cantidad)));
@@ -503,9 +519,11 @@ namespace Lbl.Articulos
                                                 this.Connection.ExecuteNonQuery(ActualizarCantidadSituacion);
                                         }
 
-                                        if (seguimiento != null) {
+                                        if (seguimiento != null)
+                                        {
                                                 // Resto las cantidades de la situación de origen
-                                                foreach (Lbl.Articulos.DatosSeguimiento Dat in seguimiento) {
+                                                foreach (Lbl.Articulos.DatosSeguimiento Dat in seguimiento)
+                                                {
                                                         qGen.Update ActualizarSeries = new qGen.Update("articulos_series");
                                                         if (Dat.Cantidad > 0)
                                                                 ActualizarSeries.ColumnValues.AddWithValue("cantidad", new qGen.SqlExpression(@"""cantidad""-" + Lfx.Types.Formatting.FormatStockSql(Dat.Cantidad)));
@@ -523,16 +541,19 @@ namespace Lbl.Articulos
                                 }
 
                                 // stock entrante (situación de destino)
-                                if (situacionDestino != null && situacionDestino.CuentaExistencias) {
+                                if (situacionDestino != null && situacionDestino.CuentaExistencias)
+                                {
                                         int ExisteSituacion = this.Connection.FieldInt("SELECT COUNT(id_articulo) FROM articulos_stock WHERE id_articulo=" + this.Id.ToString() + " AND id_situacion=" + situacionDestino.Id.ToString());
-                                        if (ExisteSituacion == 0) {
+                                        if (ExisteSituacion == 0)
+                                        {
                                                 // No existen datos de stock para esta situación... la creo
                                                 qGen.Insert InsertarCantidadSituacion = new qGen.Insert("articulos_stock");
                                                 InsertarCantidadSituacion.ColumnValues.AddWithValue("id_articulo", this.Id);
                                                 InsertarCantidadSituacion.ColumnValues.AddWithValue("id_situacion", situacionDestino.Id);
                                                 InsertarCantidadSituacion.ColumnValues.AddWithValue("cantidad", cantidad);
                                                 this.Connection.ExecuteNonQuery(InsertarCantidadSituacion);
-                                        } else {
+                                        } else
+                                        {
                                                 // Actualizo el stock en la nueva situación
                                                 qGen.Update ActualizarCantidadSituacion = new qGen.Update("articulos_stock");
                                                 ActualizarCantidadSituacion.ColumnValues.AddWithValue("cantidad", new qGen.SqlExpression(@"""cantidad""+" + Lfx.Types.Formatting.FormatStockSql(cantidad)));
@@ -542,11 +563,14 @@ namespace Lbl.Articulos
                                                 this.Connection.ExecuteNonQuery(ActualizarCantidadSituacion);
                                         }
 
-                                        if (seguimiento != null) {
+                                        if (seguimiento != null)
+                                        {
                                                 // Agrego las cantidades en la situación de destino
-                                                foreach (Lbl.Articulos.DatosSeguimiento Dat in seguimiento) {
+                                                foreach (Lbl.Articulos.DatosSeguimiento Dat in seguimiento)
+                                                {
                                                         int ExisteVariacion = this.Connection.FieldInt("SELECT COUNT(id_articulo) FROM articulos_series WHERE id_articulo=" + this.Id.ToString() + " AND id_situacion=" + situacionDestino.Id.ToString() + " AND serie='" + Dat.Variacion + "'");
-                                                        if (ExisteVariacion > 0) {
+                                                        if (ExisteVariacion > 0)
+                                                        {
                                                                 qGen.Update ActualizarSeries = new qGen.Update("articulos_series");
                                                                 if (Dat.Cantidad > 0)
                                                                         ActualizarSeries.ColumnValues.AddWithValue("cantidad", new qGen.SqlExpression(@"""cantidad""+" + Lfx.Types.Formatting.FormatStockSql(Dat.Cantidad)));
@@ -557,7 +581,8 @@ namespace Lbl.Articulos
                                                                 ActualizarSeries.WhereClause.Add(new qGen.ComparisonCondition("id_situacion", situacionDestino.Id));
                                                                 ActualizarSeries.WhereClause.Add(new qGen.ComparisonCondition("serie", Dat.Variacion));
                                                                 this.Connection.ExecuteNonQuery(ActualizarSeries);
-                                                        } else {
+                                                        } else
+                                                        {
                                                                 qGen.Insert InsertarSerie = new qGen.Insert("articulos_series");
                                                                 InsertarSerie.ColumnValues.AddWithValue("id_articulo", this.Id);
                                                                 InsertarSerie.ColumnValues.AddWithValue("id_situacion", situacionDestino.Id);
@@ -572,7 +597,8 @@ namespace Lbl.Articulos
                                 }
 
                                 // Actualizo el stock actual
-                                if (CantidadEntranteOSaliente != 0) {
+                                if (CantidadEntranteOSaliente != 0)
+                                {
                                         qGen.Update ActualizarCantidad = new qGen.Update("articulos");
                                         ActualizarCantidad.ColumnValues.AddWithValue("stock_actual", new qGen.SqlExpression(@"""stock_actual""+" + Lfx.Types.Formatting.FormatStockSql(CantidadEntranteOSaliente)));
                                         ActualizarCantidad.WhereClause = new qGen.Where("id_articulo", this.Id);
@@ -581,9 +607,11 @@ namespace Lbl.Articulos
                                         // Si ees un artículo compuesto
                                         // Propagar los cambios de stock hacia abajo.
                                         // Es decir, hacer movimientos de stock de los ingredientes (sub artículos)
-                                        if (this.TipoDeArticulo == Articulos.TiposDeArticulo.ProductoCompuesto) {
+                                        if (this.TipoDeArticulo == Articulos.TiposDeArticulo.ProductoCompuesto)
+                                        {
                                                 string ObsSubItems = "Movim. s/salida de " + this.ToString();
-                                                foreach (ItemReceta Itm in this.Receta) {
+                                                foreach (ItemReceta Itm in this.Receta)
+                                                {
                                                         Itm.Articulo.MoverExistencias(comprob, Itm.Cantidad * cantidad, ObsSubItems, situacionOrigen, situacionDestino, seguimiento);
                                                 }
                                         }
@@ -591,8 +619,10 @@ namespace Lbl.Articulos
                                         // Propagar los cambios de stock hacia arriba.
                                         // Es decir, si este artículo es ingrediente en la receta de otros artículos, actualizar los artículos padre para que reflejen el cambio de stock de este ingrediente.
                                         ColeccionGenerica<Articulo> SuperArts = this.SuperArticulos();
-                                        if (SuperArts != null) {
-                                                foreach (Articulo SuperArt in SuperArts) {
+                                        if (SuperArts != null)
+                                        {
+                                                foreach (Articulo SuperArt in SuperArts)
+                                                {
                                                         qGen.Update UpdateSuperArt = new qGen.Update("articulos");
                                                         UpdateSuperArt.ColumnValues.AddWithValue("stock_actual", SuperArt.ObtenerExistencias());
                                                         UpdateSuperArt.WhereClause = new qGen.Where("id_articulo", SuperArt.Id);
@@ -608,33 +638,34 @@ namespace Lbl.Articulos
                                                 new Lbl.Personas.Persona(this.Connection, Lbl.Sys.Config.Actual.UsuarioConectado.Id), this.Pvp * cantidad, Obs, null, null, null);
 
                                 Saldo = this.Connection.FieldDecimal("SELECT stock_actual FROM articulos WHERE id_articulo=" + this.Id.ToString());
-                        } else {
+                        } else
+                        {
                                 // No controla stock
                                 Saldo = 0;
                         }
 
                         qGen.IStatement Comando = new qGen.Insert("articulos_movim");
                         Comando.ColumnValues.AddWithValue("fecha", new qGen.SqlExpression("NOW()"));
-			Comando.ColumnValues.AddWithValue("id_articulo", this.Id);
-			Comando.ColumnValues.AddWithValue("cantidad", cantidad);
-			if(situacionOrigen == null)
-				Comando.ColumnValues.AddWithValue("desdesituacion", null);
-			else
-				Comando.ColumnValues.AddWithValue("desdesituacion", situacionOrigen.Id);
-			if(situacionDestino == null)
+                        Comando.ColumnValues.AddWithValue("id_articulo", this.Id);
+                        Comando.ColumnValues.AddWithValue("cantidad", cantidad);
+                        if (situacionOrigen == null)
+                                Comando.ColumnValues.AddWithValue("desdesituacion", null);
+                        else
+                                Comando.ColumnValues.AddWithValue("desdesituacion", situacionOrigen.Id);
+                        if (situacionDestino == null)
                                 Comando.ColumnValues.AddWithValue("haciasituacion", null);
-			else
-				Comando.ColumnValues.AddWithValue("haciasituacion", situacionDestino.Id);
-			Comando.ColumnValues.AddWithValue("saldo", Saldo);
-			Comando.ColumnValues.AddWithValue("obs", obs);
+                        else
+                                Comando.ColumnValues.AddWithValue("haciasituacion", situacionDestino.Id);
+                        Comando.ColumnValues.AddWithValue("saldo", Saldo);
+                        Comando.ColumnValues.AddWithValue("obs", obs);
                         Comando.ColumnValues.AddWithValue("series", seguimiento);
                         if (comprob == null)
                                 Comando.ColumnValues.AddWithValue("id_comprob", null);
                         else
                                 Comando.ColumnValues.AddWithValue("id_comprob", comprob.Id);
-			
-			this.Connection.ExecuteNonQuery(Comando);
-		}
+
+                        this.Connection.ExecuteNonQuery(Comando);
+                }
 
                 /// <summary>
                 /// Devuelve una colección de artículos de los cuales este es un ingrediente.
@@ -653,16 +684,16 @@ namespace Lbl.Articulos
                 /// El precio de costo o de compra.
                 /// </summary>
                 public decimal Costo
-		{
-			get
-			{
-				return this.GetFieldValue<decimal>("costo");
-			}
-			set
-			{
-				Registro["costo"] = value;
-			}
-		}
+                {
+                        get
+                        {
+                                return this.GetFieldValue<decimal>("costo");
+                        }
+                        set
+                        {
+                                Registro["costo"] = value;
+                        }
+                }
 
 
                 /// <summary>
@@ -672,11 +703,14 @@ namespace Lbl.Articulos
                 {
                         get
                         {
-                                if (m_Receta == null) {
+                                if (m_Receta == null)
+                                {
                                         m_Receta = new Receta();
-                                        if (this.Existe) {
+                                        if (this.Existe)
+                                        {
                                                 System.Data.DataTable Arts = this.Connection.Select("SELECT id_item, cantidad FROM articulos_recetas WHERE id_articulo=" + this.Id.ToString());
-                                                foreach (System.Data.DataRow Art in Arts.Rows) {
+                                                foreach (System.Data.DataRow Art in Arts.Rows)
+                                                {
                                                         ItemReceta Itm = new ItemReceta(new Articulo(this.Connection, System.Convert.ToInt32(Art["id_item"])), System.Convert.ToDecimal(Art["cantidad"]));
                                                         m_Receta.Add(Itm);
                                                 }
@@ -786,21 +820,24 @@ namespace Lbl.Articulos
                 {
                         decimal PvpOriginal = 0, CostoOriginal = 0;
 
-                        if (this.Existe) {
+                        if (this.Existe)
+                        {
                                 PvpOriginal = System.Convert.ToDecimal(this.RegistroOriginal["pvp"]);
                                 CostoOriginal = System.Convert.ToDecimal(this.RegistroOriginal["costo"]);
                         }
 
-			qGen.IStatement Comando;
+                        qGen.IStatement Comando;
 
-                        if (this.Existe == false) {
-				Comando = new qGen.Insert(this.TablaDatos);
-				Comando.ColumnValues.AddWithValue("fecha_creado", new qGen.SqlExpression("NOW()"));
-				Comando.ColumnValues.AddWithValue("fecha_precio", new qGen.SqlExpression("NOW()"));
-			} else {
-				Comando = new qGen.Update(this.TablaDatos);
+                        if (this.Existe == false)
+                        {
+                                Comando = new qGen.Insert(this.TablaDatos);
+                                Comando.ColumnValues.AddWithValue("fecha_creado", new qGen.SqlExpression("NOW()"));
+                                Comando.ColumnValues.AddWithValue("fecha_precio", new qGen.SqlExpression("NOW()"));
+                        } else
+                        {
+                                Comando = new qGen.Update(this.TablaDatos);
                                 Comando.WhereClause = new qGen.Where(this.CampoId, this.Id);
-			}
+                        }
 
                         Comando.ColumnValues.AddWithValue("codigo1", this.Codigo1);
                         Comando.ColumnValues.AddWithValue("codigo2", this.Codigo2);
@@ -841,7 +878,7 @@ namespace Lbl.Articulos
                                 Comando.ColumnValues.AddWithValue("id_margen", null);
                         else
                                 Comando.ColumnValues.AddWithValue("id_margen", this.Margen.Id);
-                        
+
                         Comando.ColumnValues.AddWithValue("pvp", this.Pvp);
                         Comando.ColumnValues.AddWithValue("control_stock", (int)(this.TipoDeArticulo));
                         Comando.ColumnValues.AddWithValue("seguimiento", (int)(this.Seguimiento));
@@ -854,7 +891,7 @@ namespace Lbl.Articulos
                         Comando.ColumnValues.AddWithValue("unidad_rend", this.UnidadRendimiento);
                         Comando.ColumnValues.AddWithValue("garantia", this.Garantia);
                         Comando.ColumnValues.AddWithValue("estado", this.Estado);
-                        switch(this.Publicacion)
+                        switch (this.Publicacion)
                         {
                                 case Publicacion.Nunca:
                                         Comando.ColumnValues.AddWithValue("web", 0);
@@ -868,22 +905,26 @@ namespace Lbl.Articulos
                                         break;
                         }
 
-			this.AgregarTags(Comando);
+                        this.AgregarTags(Comando);
 
                         this.Connection.ExecuteNonQuery(Comando);
 
-                        if (this.Existe == false) {
+                        if (this.Existe == false)
+                        {
                                 this.ActualizarId();
 
                                 if (this.ExistenciasInicial != 0)
                                         // Hago el movimiento de stock inicial
                                         this.MoverExistencias(null, this.ExistenciasInicial, "Creación del artículo - Existencias iniciales", null, new Situacion(this.Connection, 1), null);
-                        } else {
-                                if (CostoOriginal != this.Costo) {
+                        } else
+                        {
+                                if (CostoOriginal != this.Costo)
+                                {
                                         // Cambió el costo
                                         this.RecalcularCostoSuperArticulos();
                                 }
-                                if (PvpOriginal != this.Pvp) {
+                                if (PvpOriginal != this.Pvp)
+                                {
                                         // Cambió el PVP
                                         // Actualizo la fecha del precio
                                         qGen.Update ActualizarPrecio = new qGen.Update(this.TablaDatos);
@@ -893,7 +934,7 @@ namespace Lbl.Articulos
                                         this.Connection.ExecuteNonQuery(ActualizarPrecio);
 
                                         // Y creo un evento en el historial de precios
-					qGen.Insert AgregarAlHistorialDePrecios = new qGen.Insert("articulos_precios");
+                                        qGen.Insert AgregarAlHistorialDePrecios = new qGen.Insert("articulos_precios");
                                         AgregarAlHistorialDePrecios.ColumnValues.AddWithValue("id_articulo", this.Id);
                                         AgregarAlHistorialDePrecios.ColumnValues.AddWithValue("costo", this.Costo);
                                         AgregarAlHistorialDePrecios.ColumnValues.AddWithValue("fecha", new qGen.SqlExpression("NOW()"));
@@ -913,8 +954,10 @@ namespace Lbl.Articulos
                         this.Connection.ExecuteNonQuery(EliminarReceta);
 
                         // Guardar la receta del artículo, si corresponde
-                        if (this.TipoDeArticulo == Articulos.TiposDeArticulo.ProductoCompuesto && this.Receta != null) {
-                                foreach (ItemReceta Itm in this.Receta) {
+                        if (this.TipoDeArticulo == Articulos.TiposDeArticulo.ProductoCompuesto && this.Receta != null)
+                        {
+                                foreach (ItemReceta Itm in this.Receta)
+                                {
                                         qGen.Insert InsertarItemReceta = new qGen.Insert("articulos_recetas");
                                         InsertarItemReceta.ColumnValues.AddWithValue("id_articulo", this.Id);
                                         InsertarItemReceta.ColumnValues.AddWithValue("id_item", Itm.Articulo.Id);
@@ -933,8 +976,10 @@ namespace Lbl.Articulos
                 public void RecalcularCostoSuperArticulos()
                 {
                         ColeccionGenerica<Articulo> SuperArts = this.SuperArticulos();
-                        if (SuperArts != null) {
-                                foreach (Articulo SuperArt in SuperArts) {
+                        if (SuperArts != null)
+                        {
+                                foreach (Articulo SuperArt in SuperArts)
+                                {
                                         SuperArt.Cargar();
                                         qGen.Update UpdateSuperArt = new qGen.Update("articulos");
                                         UpdateSuperArt.ColumnValues.AddWithValue("costo", SuperArt.ObtenerCosto());
@@ -960,5 +1005,5 @@ namespace Lbl.Articulos
                         this.Connection.ExecuteNonQuery(ActCmd);
                         Lbl.Sys.Config.ActionLog(this.Connection, Lbl.Sys.Log.Acciones.Delete, this, activar ? "Activar" : "Desactivar");
                 }
-	}
+        }
 }

--- a/Lbl/Articulos/ItemReceta.cs
+++ b/Lbl/Articulos/ItemReceta.cs
@@ -27,7 +27,7 @@ namespace Lbl.Articulos
                 {
                         get
                         {
-                                return this.Articulo.Costo * this.Cantidad;
+                                return this.Articulo.CostoLocal * this.Cantidad;
                         }
                 }
 
@@ -35,7 +35,7 @@ namespace Lbl.Articulos
                 {
                         get
                         {
-                                return this.Articulo.Pvp * this.Cantidad;
+                                return this.Articulo.PvpLocal * this.Cantidad;
                         }
                 }
         }

--- a/Lbl/Comprobantes/ComprobanteConArticulos.cs
+++ b/Lbl/Comprobantes/ComprobanteConArticulos.cs
@@ -925,10 +925,11 @@ namespace Lbl.Comprobantes
                 public override Lfx.Types.OperationResult Guardar()
                 {
                         this.Articulos.ElementoPadre = this;
+                        Lbl.Entidades.Pais PaisActual = new Lbl.Entidades.Pais(this.Connection, Lfx.Workspace.Master.CurrentConfig.ReadGlobalSetting<int>("Sistema.Pais", 1));
 
-			qGen.IStatement Comando;
+                        qGen.IStatement Comando;
                         if (this.Total <= 0)
-                                return new Lfx.Types.FailureOperationResult("El comprobante debe tener un importe superior a $ 0.00.");
+                                return new Lfx.Types.FailureOperationResult("El comprobante debe tener un importe superior a " + PaisActual.Moneda.Simbolo + " 0.00.");
 
 			if (this.Existe == false) {
                                 Comando = new qGen.Insert(this.TablaDatos);

--- a/Lbl/Comprobantes/ComprobanteConArticulos.cs
+++ b/Lbl/Comprobantes/ComprobanteConArticulos.cs
@@ -1127,7 +1127,7 @@ namespace Lbl.Comprobantes
                                                 Comando.ColumnValues.AddWithValue("iva", Art.ImporteIvaUnitario);
                                                 Comando.ColumnValues.AddWithValue("recargo", Art.Recargo);
                                                 if (Art.Costo == 0 && Art.Articulo != null)
-                                                        Comando.ColumnValues.AddWithValue("costo", Art.Articulo.Costo);
+                                                        Comando.ColumnValues.AddWithValue("costo", Art.Articulo.CostoLocal);
                                                 else
                                                         Comando.ColumnValues.AddWithValue("costo", Art.Costo);
                                                 Comando.ColumnValues.AddWithValue("importe", Art.ImporteAImprimir);

--- a/Lbl/Entidades/Moneda.cs
+++ b/Lbl/Entidades/Moneda.cs
@@ -59,6 +59,17 @@ namespace Lbl.Entidades
                         }
                 }
 
+                public string Nombre
+                {
+                        get
+                        {
+                                return this.GetFieldValue<string>("nombre");
+                        }
+                        set
+                        {
+                                this.Registro["nombre"] = value;
+                        }
+                }
 
                 public int Decimales
                 {

--- a/Lbl/Entidades/Moneda.cs
+++ b/Lbl/Entidades/Moneda.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using Lazaro.Orm;
+using Lazaro.Orm.Attributes;
 
 namespace Lbl.Entidades
 {
@@ -10,6 +12,8 @@ namespace Lbl.Entidades
         [Lbl.Atributos.Nomenclatura(NombreSingular = "Moneda", Grupo = "Cuentas")]
         [Lbl.Atributos.Datos(TablaDatos = "monedas", CampoId = "id_moneda")]
         [Lbl.Atributos.Presentacion()]
+
+        [Entity(TableName = "monedas", IdFieldName = "id_moneda")]
         public class Moneda : ElementoDeDatos
         {
                 //Heredar constructor
@@ -81,6 +85,22 @@ namespace Lbl.Entidades
                         {
                                 this.Registro["decimales"] = value;
                         }
+                }
+
+                public override Lfx.Types.OperationResult Guardar()
+                {
+                        qGen.IStatement Comando;
+                        
+                        Comando = new qGen.Update("monedas");
+                        Comando.WhereClause = new qGen.Where("id_moneda", m_ItemId);
+                        
+
+                        if (this.Cotizacion > 0)
+                                Comando.ColumnValues.AddWithValue("cotizacion", this.Cotizacion);                        
+
+                        Connection.ExecuteNonQuery(Comando);
+
+                        return base.Guardar();
                 }
         }
 }

--- a/Lbl/Entidades/Moneda.cs
+++ b/Lbl/Entidades/Moneda.cs
@@ -75,6 +75,15 @@ namespace Lbl.Entidades
                         }
                 }
 
+                [Column(Name = "fecha")]
+                public DbDateTime Fecha
+                {
+                        get
+                        {
+                                return this.GetFieldValue<DbDateTime>("fecha");
+                        }
+                }
+
                 public int Decimales
                 {
                         get
@@ -90,13 +99,27 @@ namespace Lbl.Entidades
                 public override Lfx.Types.OperationResult Guardar()
                 {
                         qGen.IStatement Comando;
-                        
-                        Comando = new qGen.Update("monedas");
-                        Comando.WhereClause = new qGen.Where("id_moneda", m_ItemId);
+                        if (this.Existe == false)
+                        {
+                                Comando = new qGen.Insert(this.TablaDatos);
+                                Comando.ColumnValues.AddWithValue("fecha", new qGen.SqlExpression("NOW()"));
+                                Comando.ColumnValues.AddWithValue("estado", 1);
+                                Comando.ColumnValues.AddWithValue("decimales", 2);
+
+                        } else
+                        {
+                                Comando = new qGen.Update("monedas");
+                                Comando.WhereClause = new qGen.Where("id_moneda", m_ItemId);
+                                Comando.ColumnValues.AddWithValue("fecha", new qGen.SqlExpression("NOW()"));
+                        }
                         
 
+                        Comando.ColumnValues.AddWithValue("nombre", this.Nombre);
+                        Comando.ColumnValues.AddWithValue("iso", this.NomenclaturaIso);
+                        Comando.ColumnValues.AddWithValue("signo", this.Simbolo);
                         if (this.Cotizacion > 0)
-                                Comando.ColumnValues.AddWithValue("cotizacion", this.Cotizacion);                        
+                                Comando.ColumnValues.AddWithValue("cotizacion", this.Cotizacion);  
+                        
 
                         Connection.ExecuteNonQuery(Comando);
 

--- a/Lbl/Util/Impresion/Comprobantes/ImpresorComprobanteConArticulos.cs
+++ b/Lbl/Util/Impresion/Comprobantes/ImpresorComprobanteConArticulos.cs
@@ -43,7 +43,7 @@ namespace Lazaro.Base.Util.Impresion.Comprobantes
                                 foreach (Lbl.Comprobantes.DetalleArticulo Det in this.Comprobante.Articulos) {
                                         if (Det.Articulo != null) {
                                                 qGen.Update Act = new qGen.Update("comprob_detalle");
-                                                Act.ColumnValues.AddWithValue("costo", Det.Articulo.Costo);
+                                                Act.ColumnValues.AddWithValue("costo", Det.Articulo.CostoLocal);
                                                 Act.WhereClause = new qGen.Where("id_comprob_detalle", Det.Id);
                                                 this.Connection.ExecuteNonQuery(Act);
                                         }

--- a/Lcc/Entrada/Articulos/DetalleComprobante.cs
+++ b/Lcc/Entrada/Articulos/DetalleComprobante.cs
@@ -293,7 +293,7 @@ namespace Lcc.Entrada.Articulos
 
                                 if (m_DiscriminarIva != AntesDiscriminaba && m_AplicarIva && m_Alicuota != null) {
                                         if (value) {
-                                                // Antes no discriminaba y ahora sí
+                                                // Antes no discriminaba y ahora sï¿½
                                                 this.EstablecerImporteUnitarioOriginal(this.ImporteUnitario / (1 + m_Alicuota.Porcentaje / 100m));
                                         } else {
                                                 // Antes discriminaba y ahora no
@@ -330,7 +330,7 @@ namespace Lcc.Entrada.Articulos
                                 if (m_AplicarIva != AntesAplicaba && m_Alicuota != null) {
                                         decimal NuevoImporteUnitarioIva = this.ImporteUnitario * (m_Alicuota.Porcentaje / 100m);
                                         if (value) {
-                                                // Antes no aplicaba y ahora sí
+                                                // Antes no aplicaba y ahora sï¿½
                                                 this.EstablecerImporteUnitarioOriginal(this.ImporteUnitario);
                                         } else {
                                                 // Antes aplicaba y ahora no
@@ -481,7 +481,7 @@ namespace Lcc.Entrada.Articulos
                 }
 
                 /// <summary>
-                /// El importe de IVA discriminado unitario (sin descuento), o 0 si el IVA no está discriminado.
+                /// El importe de IVA discriminado unitario (sin descuento), o 0 si el IVA no estï¿½ discriminado.
                 /// </summary>
                 [EditorBrowsable(EditorBrowsableState.Never), Browsable(false), DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
                 public decimal ImporteIvaDiscriminadoUnitario
@@ -925,9 +925,9 @@ namespace Lcc.Entrada.Articulos
 
                                         decimal UnitarioMostrar;
                                         if (m_Precio == Precios.Costo) {
-                                                UnitarioMostrar = Articulo.Costo;
+                                                UnitarioMostrar = Articulo.CostoLocal;
                                         } else {
-                                                UnitarioMostrar = Articulo.Pvp;
+                                                UnitarioMostrar = Articulo.PvpLocal;
                                         }
 
                                         if (this.Cantidad == 0) {
@@ -969,9 +969,9 @@ namespace Lcc.Entrada.Articulos
 
 
                 /// <summary>
-                /// Cambia el importe unitario original (sin IVA), y además recalcula el IVA y lo muestra discriminado si corresponde.
+                /// Cambia el importe unitario original (sin IVA), y ademï¿½s recalcula el IVA y lo muestra discriminado si corresponde.
                 /// </summary>
-                /// <param name="unitario">El precio unitario a mostrar y usar como base para el cálculo de IVA e importe final.</param>
+                /// <param name="unitario">El precio unitario a mostrar y usar como base para el cï¿½lculo de IVA e importe final.</param>
                 protected void EstablecerImporteUnitarioOriginal(decimal unitario)
                 {
                         if (this.AplicarIva && m_Alicuota != null) {
@@ -992,7 +992,7 @@ namespace Lcc.Entrada.Articulos
 
 
                 /// <summary>
-                /// Recalcula el importe final, según importe, IVA, cantidad y descuento.
+                /// Recalcula el importe final, segï¿½n importe, IVA, cantidad y descuento.
                 /// </summary>
                 protected void RecalcularImporteFinal()
                 {

--- a/Lfc/Articulos/CambioMasivoPrecios.Designer.cs
+++ b/Lfc/Articulos/CambioMasivoPrecios.Designer.cs
@@ -33,6 +33,7 @@ namespace Lfc.Articulos
                         this.ColPvp = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
                         this.ColPvp2 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
                         this.EntradaPrecio = new Lui.Forms.ComboBox();
+                        this.ColMoneda = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
                         this.SuspendLayout();
                         // 
                         // Label2
@@ -85,7 +86,7 @@ namespace Lfc.Articulos
             | System.Windows.Forms.AnchorStyles.Right)));
                         this.label10.Location = new System.Drawing.Point(24, 56);
                         this.label10.Name = "label10";
-                        this.label10.Size = new System.Drawing.Size(668, 33);
+                        this.label10.Size = new System.Drawing.Size(687, 33);
                         this.label10.TabIndex = 1;
                         this.label10.Text = "Va a realizar un cambio de precios para todos los artículos del listado.";
                         // 
@@ -107,7 +108,7 @@ namespace Lfc.Articulos
                         this.EntradaUnidad.Name = "EntradaUnidad";
                         this.EntradaUnidad.SetData = new string[] {
         "Porcentaje|pct",
-        "Pesos|pesos"};
+        "Valor|pesos"};
                         this.EntradaUnidad.Size = new System.Drawing.Size(117, 40);
                         this.EntradaUnidad.TabIndex = 4;
                         this.EntradaUnidad.TextKey = "pct";
@@ -121,6 +122,7 @@ namespace Lfc.Articulos
                         this.Listado.BorderStyle = System.Windows.Forms.BorderStyle.None;
                         this.Listado.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
             this.ColArticulo,
+            this.ColMoneda,
             this.ColCosto,
             this.ColCosto2,
             this.ColPvp,
@@ -131,7 +133,7 @@ namespace Lfc.Articulos
                         this.Listado.MultiSelect = false;
                         this.Listado.Name = "Listado";
                         this.Listado.ReadOnly = true;
-                        this.Listado.Size = new System.Drawing.Size(673, 256);
+                        this.Listado.Size = new System.Drawing.Size(692, 256);
                         this.Listado.TabIndex = 8;
                         this.Listado.TabStop = false;
                         this.Listado.UseCompatibleStateImageBehavior = false;
@@ -181,11 +183,15 @@ namespace Lfc.Articulos
                         this.EntradaPrecio.TextKey = "pvp";
                         this.EntradaPrecio.TextChanged += new System.EventHandler(this.EntradaPrecio_TextChanged);
                         // 
+                        // ColMoneda
+                        // 
+                        this.ColMoneda.Text = "Moneda";
+                        // 
                         // CambioMasivoPrecios
                         // 
                         this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
                         this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
-                        this.ClientSize = new System.Drawing.Size(723, 528);
+                        this.ClientSize = new System.Drawing.Size(742, 528);
                         this.Controls.Add(this.EntradaPrecio);
                         this.Controls.Add(this.Listado);
                         this.Controls.Add(this.EntradaUnidad);
@@ -227,5 +233,6 @@ namespace Lfc.Articulos
                 private System.Windows.Forms.ColumnHeader ColCosto2;
                 private System.Windows.Forms.ColumnHeader ColPvp;
                 private System.Windows.Forms.ColumnHeader ColPvp2;
+                private System.Windows.Forms.ColumnHeader ColMoneda;
         }
 }

--- a/Lfc/Articulos/Editar.Designer.cs
+++ b/Lfc/Articulos/Editar.Designer.cs
@@ -5,6 +5,8 @@ namespace Lfc.Articulos
                 private void InitializeComponent()
                 {
                         this.Frame2 = new Lui.Forms.Frame();
+                        this.label24 = new Lui.Forms.Label();
+                        this.EntradaMoneda = new Lcc.Entrada.CodigoDetalle();
                         this.EntradaPvpIva = new Lui.Forms.TextBox();
                         this.label23 = new Lui.Forms.Label();
                         this.EntradaCosto = new Lui.Forms.TextBox();
@@ -74,6 +76,8 @@ namespace Lfc.Articulos
                         // 
                         // Frame2
                         // 
+                        this.Frame2.Controls.Add(this.label24);
+                        this.Frame2.Controls.Add(this.EntradaMoneda);
                         this.Frame2.Controls.Add(this.EntradaPvpIva);
                         this.Frame2.Controls.Add(this.label23);
                         this.Frame2.Controls.Add(this.EntradaCosto);
@@ -93,6 +97,32 @@ namespace Lfc.Articulos
                         this.Frame2.Size = new System.Drawing.Size(360, 316);
                         this.Frame2.TabIndex = 0;
                         this.Frame2.Text = "Precio y costo";
+                        // 
+                        // label24
+                        // 
+                        this.label24.Location = new System.Drawing.Point(8, 64);
+                        this.label24.Name = "label24";
+                        this.label24.Size = new System.Drawing.Size(120, 24);
+                        this.label24.TabIndex = 36;
+                        this.label24.Text = "Tipo de Moneda";
+                        this.label24.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+                        // 
+                        // EntradaMoneda
+                        // 
+                        this.EntradaMoneda.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+                        this.EntradaMoneda.AutoTab = true;
+                        this.EntradaMoneda.CanCreate = true;
+                        this.EntradaMoneda.Location = new System.Drawing.Point(136, 67);
+                        this.EntradaMoneda.MaximumSize = new System.Drawing.Size(480, 32);
+                        this.EntradaMoneda.MaxLength = 0;
+                        this.EntradaMoneda.Name = "EntradaMoneda";
+                        this.EntradaMoneda.NombreTipo = "Lbl.Entidades.Monedas";
+                        this.EntradaMoneda.PlaceholderText = "Tipo de Moneda";
+                        this.EntradaMoneda.Required = false;
+                        this.EntradaMoneda.Size = new System.Drawing.Size(221, 24);
+                        this.EntradaMoneda.TabIndex = 35;
+                        this.EntradaMoneda.Text = "0";
                         // 
                         // EntradaPvpIva
                         // 
@@ -133,11 +163,11 @@ namespace Lfc.Articulos
                         // EntradaMargen
                         // 
                         this.EntradaMargen.AlwaysExpanded = true;
-                        this.EntradaMargen.Location = new System.Drawing.Point(136, 72);
+                        this.EntradaMargen.Location = new System.Drawing.Point(136, 97);
                         this.EntradaMargen.Name = "EntradaMargen";
                         this.EntradaMargen.SetData = new string[] {
         "Otro|-1"};
-                        this.EntradaMargen.Size = new System.Drawing.Size(224, 96);
+                        this.EntradaMargen.Size = new System.Drawing.Size(224, 71);
                         this.EntradaMargen.TabIndex = 4;
                         this.EntradaMargen.TextKey = "-1";
                         this.EntradaMargen.TextChanged += new System.EventHandler(this.EntradaCostoMargen_TextChanged);
@@ -196,7 +226,7 @@ namespace Lfc.Articulos
                         // 
                         // Label8
                         // 
-                        this.Label8.Location = new System.Drawing.Point(8, 72);
+                        this.Label8.Location = new System.Drawing.Point(13, 97);
                         this.Label8.Name = "Label8";
                         this.Label8.Size = new System.Drawing.Size(120, 24);
                         this.Label8.TabIndex = 3;
@@ -906,5 +936,7 @@ namespace Lfc.Articulos
                 internal Lui.Forms.Panel PanelProducto;
                 internal Lui.Forms.TextBox EntradaPvpIva;
                 internal Lui.Forms.Label label23;
+                internal Lcc.Entrada.CodigoDetalle EntradaMoneda;
+                internal Lui.Forms.Label label24;
         }
 }

--- a/Lfc/Articulos/Editar.cs
+++ b/Lfc/Articulos/Editar.cs
@@ -54,7 +54,8 @@ namespace Lfc.Articulos
                                 int i = 0;
                                 string[] ListaMargenes = new string[this.Margenes.Count + 1];
 
-                                //TODO Ordenar de forma acendente this.Margenes usando Margen.nombre como valor a ordenar.
+                                //Ordeno el listado de Margenes
+                                this.Margenes.Sort((x, y) => x.Porcentaje.CompareTo(y.Porcentaje));
 
                                 foreach (Lbl.Articulos.Margen Mg in this.Margenes) {
                                         ListaMargenes[i] = Mg.Nombre + " (" + Lfx.Types.Formatting.FormatNumber(Mg.Porcentaje, 2) + "%)|" + Mg.Id.ToString();

--- a/Lfc/Articulos/Editar.cs
+++ b/Lfc/Articulos/Editar.cs
@@ -254,6 +254,7 @@ namespace Lfc.Articulos
                 public override void ActualizarControl()
                 {
                         Lbl.Articulos.Articulo Art = this.Elemento as Lbl.Articulos.Articulo;
+                        Lbl.Entidades.Pais PaisActual;
 
                         EntradaCodigo1.Text = Art.Codigo1;
                         EntradaCodigo2.Text = Art.Codigo2;
@@ -299,7 +300,14 @@ namespace Lfc.Articulos
                         UnidadRendimiento = Art.UnidadRendimiento;
                         EntradaStockMinimo.ValueDecimal = Art.PuntoDeReposicion;
                         EntradaGarantia.ValueInt = Art.Garantia;
-                        EntradaMoneda.Elemento = Art.Moneda;
+                        if (Art.Moneda == null)
+                        {
+                                PaisActual = new Lbl.Entidades.Pais(this.Connection, Lfx.Workspace.Master.CurrentConfig.ReadGlobalSetting<int>("Sistema.Pais", 1));
+                                EntradaMoneda.Elemento = PaisActual.Moneda;
+                        } else
+                        {
+                                EntradaMoneda.Elemento = Art.Moneda;
+                        }
                         CustomName = Art.Existe;
 
                         EntradaTipoDeArticulo_TextChanged(this, null);
@@ -343,7 +351,10 @@ namespace Lfc.Articulos
                         Art.Rendimiento = Rendimiento;
                         Art.UnidadRendimiento = UnidadRendimiento;
                         Art.Estado = 1;
-                        Art.Moneda = EntradaMoneda.Elemento as Lbl.Entidades.Moneda;
+                        if (EntradaMoneda.Elemento != null)
+                                Art.Moneda = EntradaMoneda.Elemento as Lbl.Entidades.Moneda;
+                        else
+                                Art.Moneda = null;
                         Art.Garantia = EntradaGarantia.ValueInt;
                         Art.Publicacion = ((Lbl.Articulos.Publicacion)(EntradaWeb.ValueInt));
                         if (Art.Existe == false)

--- a/Lfc/Articulos/Editar.cs
+++ b/Lfc/Articulos/Editar.cs
@@ -255,7 +255,7 @@ namespace Lfc.Articulos
                 public override void ActualizarControl()
                 {
                         Lbl.Articulos.Articulo Art = this.Elemento as Lbl.Articulos.Articulo;
-                        Lbl.Entidades.Pais PaisActual;
+                        
 
                         EntradaCodigo1.Text = Art.Codigo1;
                         EntradaCodigo2.Text = Art.Codigo2;
@@ -300,15 +300,8 @@ namespace Lfc.Articulos
                         Rendimiento = Art.Rendimiento;
                         UnidadRendimiento = Art.UnidadRendimiento;
                         EntradaStockMinimo.ValueDecimal = Art.PuntoDeReposicion;
-                        EntradaGarantia.ValueInt = Art.Garantia;
-                        if (Art.Moneda == null)
-                        {
-                                PaisActual = new Lbl.Entidades.Pais(this.Connection, Lfx.Workspace.Master.CurrentConfig.ReadGlobalSetting<int>("Sistema.Pais", 1));
-                                EntradaMoneda.Elemento = PaisActual.Moneda;
-                        } else
-                        {
-                                EntradaMoneda.Elemento = Art.Moneda;
-                        }
+                        EntradaGarantia.ValueInt = Art.Garantia;                        
+                        EntradaMoneda.Elemento = Art.Moneda;                        
                         CustomName = Art.Existe;
 
                         EntradaTipoDeArticulo_TextChanged(this, null);

--- a/Lfc/Articulos/Editar.cs
+++ b/Lfc/Articulos/Editar.cs
@@ -50,9 +50,11 @@ namespace Lfc.Articulos
                                         EtiquetaCodigo4.Text = Nombre["nombre"].ToString();
 
                                 this.Margenes = new Lbl.ColeccionGenerica<Lbl.Articulos.Margen>(this.Connection, Lfx.Workspace.Master.Tables["margenes"]);
-
+                                
                                 int i = 0;
                                 string[] ListaMargenes = new string[this.Margenes.Count + 1];
+
+                                //TODO Ordenar de forma acendente this.Margenes usando Margen.nombre como valor a ordenar.
 
                                 foreach (Lbl.Articulos.Margen Mg in this.Margenes) {
                                         ListaMargenes[i] = Mg.Nombre + " (" + Lfx.Types.Formatting.FormatNumber(Mg.Porcentaje, 2) + "%)|" + Mg.Id.ToString();
@@ -297,6 +299,7 @@ namespace Lfc.Articulos
                         UnidadRendimiento = Art.UnidadRendimiento;
                         EntradaStockMinimo.ValueDecimal = Art.PuntoDeReposicion;
                         EntradaGarantia.ValueInt = Art.Garantia;
+                        EntradaMoneda.Elemento = Art.Moneda;
                         CustomName = Art.Existe;
 
                         EntradaTipoDeArticulo_TextChanged(this, null);
@@ -340,6 +343,7 @@ namespace Lfc.Articulos
                         Art.Rendimiento = Rendimiento;
                         Art.UnidadRendimiento = UnidadRendimiento;
                         Art.Estado = 1;
+                        Art.Moneda = EntradaMoneda.Elemento as Lbl.Entidades.Moneda;
                         Art.Garantia = EntradaGarantia.ValueInt;
                         Art.Publicacion = ((Lbl.Articulos.Publicacion)(EntradaWeb.ValueInt));
                         if (Art.Existe == false)

--- a/Lfc/Articulos/Inicio.cs
+++ b/Lfc/Articulos/Inicio.cs
@@ -29,7 +29,8 @@ namespace Lfc.Articulos
                                 Columns = new Lazaro.Pres.FieldCollection()
                                 {
 				        new Lazaro.Pres.Field("articulos.nombre", "Nombre", Lfx.Data.InputFieldTypes.Text, 320),
-                                        new Lazaro.Pres.Field("articulos.costo", "Costo", Lfx.Data.InputFieldTypes.Currency, 96),
+                                        new Lazaro.Pres.Field("monedas.nombre", "Cotizacion", Lfx.Data.InputFieldTypes.Text, 120),
+                                        new Lazaro.Pres.Field("monedas.cotizacion*articulos.costo", "Costo", Lfx.Data.InputFieldTypes.Currency, 96),                                        
 				        new Lazaro.Pres.Field("articulos.pvp", "PVP", Lfx.Data.InputFieldTypes.Currency, 96),
 				        new Lazaro.Pres.Field("articulos.stock_actual", "Stock Act", Lfx.Data.InputFieldTypes.Numeric, 96),
 				        new Lazaro.Pres.Field("articulos.stock_minimo", "Stock Mín", Lfx.Data.InputFieldTypes.Numeric, 96),
@@ -102,8 +103,9 @@ namespace Lfc.Articulos
 
                 private qGen.JoinCollection FixedJoins()
                 {
-                        return new qGen.JoinCollection() { 
-                                new qGen.Join("articulos_categorias", "articulos_categorias.id_categoria=articulos.id_categoria")
+                        return new qGen.JoinCollection() {
+                                new qGen.Join("articulos_categorias", "articulos_categorias.id_categoria=articulos.id_categoria"),
+                                new qGen.Join("monedas", "monedas.id_moneda=articulos.id_moneda")
                         };
                 }
 

--- a/Lfc/Articulos/Inicio.cs
+++ b/Lfc/Articulos/Inicio.cs
@@ -12,11 +12,12 @@ namespace Lfc.Articulos
                 protected internal Lbl.Articulos.Rubro m_Rubro = null;
                 protected internal Lbl.Articulos.Situacion m_Situacion = null;
                 private string m_Stock = "*";
+               
 
                 public Inicio()
                 {
                         this.InitializeComponent();
-
+                        Lbl.Entidades.Moneda MonedaLocal = ObtenerMoneda;
                         this.Definicion = new Lazaro.Pres.Listings.Listing()
                         {
                                 ElementoTipo = typeof(Lbl.Articulos.Articulo),
@@ -29,9 +30,9 @@ namespace Lfc.Articulos
                                 Columns = new Lazaro.Pres.FieldCollection()
                                 {
 				        new Lazaro.Pres.Field("articulos.nombre", "Nombre", Lfx.Data.InputFieldTypes.Text, 320),
-                                        new Lazaro.Pres.Field("monedas.nombre", "Cotizacion", Lfx.Data.InputFieldTypes.Text, 120),
-                                        new Lazaro.Pres.Field("monedas.cotizacion*articulos.costo", "Costo", Lfx.Data.InputFieldTypes.Currency, 96),                                        
-				        new Lazaro.Pres.Field("articulos.pvp", "PVP", Lfx.Data.InputFieldTypes.Currency, 96),
+                                        new Lazaro.Pres.Field("IFNULL(monedas.nombre, '"+ MonedaLocal.Nombre +"')", "Moneda", Lfx.Data.InputFieldTypes.Text, 120),                                        
+                                        new Lazaro.Pres.Field("IFNULL(monedas.cotizacion, 1)*articulos.costo", "Costo", Lfx.Data.InputFieldTypes.Currency, 96),                                        
+				        new Lazaro.Pres.Field("IFNULL(monedas.cotizacion, 1)*articulos.pvp", "PVP", Lfx.Data.InputFieldTypes.Currency, 96),
 				        new Lazaro.Pres.Field("articulos.stock_actual", "Stock Act", Lfx.Data.InputFieldTypes.Numeric, 96),
 				        new Lazaro.Pres.Field("articulos.stock_minimo", "Stock Mín", Lfx.Data.InputFieldTypes.Numeric, 96),
 				        new Lazaro.Pres.Field("articulos.pedido", "Pedidos", Lfx.Data.InputFieldTypes.Numeric, 96),
@@ -121,9 +122,10 @@ namespace Lfc.Articulos
                                         item.SubItems["stock_actual"].BackColor = System.Drawing.Color.Pink;
                                         item.SubItems["stock_actual"].BackColor = System.Drawing.Color.Pink;
                                 }
-                        }
+                        }                        
 
-                        if (item.SubItems.ContainsKey("apedir")) {
+                        if (item.SubItems.ContainsKey("apedir"))
+                        {
                                 if (row.Fields["apedir"].ValueDecimal > 0)
                                         item.SubItems["apedir"].Text = "-";
                                 else
@@ -246,6 +248,18 @@ namespace Lfc.Articulos
                         m_Stock = filters["stock_actual"].Value as string;
 
                         base.OnFiltersChanged(filters);
+                }
+                public Lbl.Entidades.Moneda ObtenerMoneda
+                {
+                        get
+                        {
+                                Lbl.Entidades.Pais PaisActual = new Lbl.Entidades.Pais(this.Connection, Lfx.Workspace.Master.CurrentConfig.ReadGlobalSetting<int>("Sistema.Pais", 1));
+                                if (PaisActual != null)
+                                        return PaisActual.Moneda;
+                                else
+                                        return  new Lbl.Entidades.Moneda(Lfx.Workspace.Master.MasterConnection, 3);
+                                
+                        }
                 }
         }
 }

--- a/Lfc/Component.cs
+++ b/Lfc/Component.cs
@@ -320,6 +320,13 @@ namespace Lfc
                                         new Lfx.Components.Action("edit", typeof(Lfc.Tareas.Tipos.Editar))
                                 }));
 
+                        Res.Add(new Lfx.Components.RegisteredType(
+                                typeof(Lbl.Entidades.Moneda),
+                                new Lfx.Components.ActionCollection() {
+                                        new Lfx.Components.Action("list", typeof(Lfc.Monedas.Inicio)),
+                                        new Lfx.Components.Action("edit", typeof(Lfc.Monedas.Editar))
+                                }));
+
                         return Res;
                 }
 

--- a/Lfc/Comprobantes/Editar.cs
+++ b/Lfc/Comprobantes/Editar.cs
@@ -37,6 +37,7 @@ namespace Lfc.Comprobantes
                 public override Lfx.Types.OperationResult ValidarControl()
                 {
                         Lfx.Types.OperationResult Res = base.ValidarControl();
+                        Lbl.Entidades.Pais PaisActual = new Lbl.Entidades.Pais(this.Connection, Lfx.Workspace.Master.CurrentConfig.ReadGlobalSetting<int>("Sistema.Pais", 1));
 
                         if (EntradaVendedor.ValueInt == 0) {
                                 Res.Success = false;
@@ -50,7 +51,7 @@ namespace Lfc.Comprobantes
 
                         if (EntradaTotal.ValueDecimal <= 0) {
                                 Res.Success = false;
-                                Res.Message += "El comprobante debe tener un importe superior a $ 0.00." + Environment.NewLine;
+                                Res.Message += "El comprobante debe tener un importe superior a " + PaisActual.Moneda.Simbolo + " 0.00." + Environment.NewLine;
                         }
 
                         if (Lbl.Comprobantes.PuntoDeVenta.TodosPorNumero.ContainsKey(EntradaPV.ValueInt) == false)

--- a/Lfc/Monedas/Editar.Designer.cs
+++ b/Lfc/Monedas/Editar.Designer.cs
@@ -1,0 +1,86 @@
+namespace Lfc.Monedas
+{
+        partial class Editar
+        {
+                private System.ComponentModel.IContainer components = null;
+
+                protected override void Dispose(bool disposing)
+                {
+                        if (disposing && (components != null))
+                        {
+                                components.Dispose();
+                        }
+                        base.Dispose(disposing);
+                }
+
+                #region Código generado por el Diseñador de Windows Forms
+
+                /// <summary>
+                /// Método necesario para admitir el Diseñador. No se puede modificar
+                /// el contenido del método con el editor de código.
+                /// </summary>
+                private void InitializeComponent()
+                {
+                        this.EntradaNombre = new Lui.Forms.TextBox();
+                        this.Label3 = new Lui.Forms.Label();
+                        this.EntradaCotizacion = new Lui.Forms.TextBox();
+                        this.label1 = new Lui.Forms.Label();
+                        this.SuspendLayout();
+                        // 
+                        // EntradaNombre
+                        // 
+                        this.EntradaNombre.Location = new System.Drawing.Point(143, 13);
+                        this.EntradaNombre.Name = "EntradaNombre";
+                        this.EntradaNombre.Size = new System.Drawing.Size(172, 24);
+                        this.EntradaNombre.TabIndex = 7;
+                        // 
+                        // Label3
+                        // 
+                        this.Label3.Location = new System.Drawing.Point(3, 13);
+                        this.Label3.Name = "Label3";
+                        this.Label3.Size = new System.Drawing.Size(140, 24);
+                        this.Label3.TabIndex = 6;
+                        this.Label3.Text = "Nombre";
+                        this.Label3.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+                        // 
+                        // EntradaCotizacion
+                        // 
+                        this.EntradaCotizacion.DataType = Lui.Forms.DataTypes.Currency;
+                        this.EntradaCotizacion.Location = new System.Drawing.Point(143, 61);
+                        this.EntradaCotizacion.Name = "EntradaCotizacion";
+                        this.EntradaCotizacion.Prefijo = "$";
+                        this.EntradaCotizacion.Size = new System.Drawing.Size(172, 24);
+                        this.EntradaCotizacion.TabIndex = 9;
+                        this.EntradaCotizacion.Text = "0.00";
+                        // 
+                        // label1
+                        // 
+                        this.label1.Location = new System.Drawing.Point(3, 61);
+                        this.label1.Name = "label1";
+                        this.label1.Size = new System.Drawing.Size(140, 24);
+                        this.label1.TabIndex = 8;
+                        this.label1.Text = "Cotización";
+                        this.label1.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+                        // 
+                        // Editar
+                        // 
+                        this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+                        this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
+                        this.Controls.Add(this.EntradaCotizacion);
+                        this.Controls.Add(this.label1);
+                        this.Controls.Add(this.EntradaNombre);
+                        this.Controls.Add(this.Label3);
+                        this.Name = "Editar";
+                        this.Size = new System.Drawing.Size(647, 314);
+                        this.ResumeLayout(false);
+
+                }
+
+                #endregion
+
+                internal Lui.Forms.TextBox EntradaNombre;
+                internal Lui.Forms.Label Label3;
+                internal Lui.Forms.TextBox EntradaCotizacion;
+                internal Lui.Forms.Label label1;
+        }
+}

--- a/Lfc/Monedas/Editar.Designer.cs
+++ b/Lfc/Monedas/Editar.Designer.cs
@@ -25,18 +25,23 @@ namespace Lfc.Monedas
                         this.Label3 = new Lui.Forms.Label();
                         this.EntradaCotizacion = new Lui.Forms.TextBox();
                         this.label1 = new Lui.Forms.Label();
+                        this.EntradaCodigoIso = new Lui.Forms.TextBox();
+                        this.label2 = new Lui.Forms.Label();
+                        this.EntradaSigno = new Lui.Forms.TextBox();
+                        this.label4 = new Lui.Forms.Label();
+                        this.LabelFechaValor = new Lui.Forms.Label();
                         this.SuspendLayout();
                         // 
                         // EntradaNombre
                         // 
-                        this.EntradaNombre.Location = new System.Drawing.Point(143, 13);
+                        this.EntradaNombre.Location = new System.Drawing.Point(151, 13);
                         this.EntradaNombre.Name = "EntradaNombre";
                         this.EntradaNombre.Size = new System.Drawing.Size(172, 24);
                         this.EntradaNombre.TabIndex = 7;
                         // 
                         // Label3
                         // 
-                        this.Label3.Location = new System.Drawing.Point(3, 13);
+                        this.Label3.Location = new System.Drawing.Point(8, 13);
                         this.Label3.Name = "Label3";
                         this.Label3.Size = new System.Drawing.Size(140, 24);
                         this.Label3.TabIndex = 6;
@@ -46,7 +51,7 @@ namespace Lfc.Monedas
                         // EntradaCotizacion
                         // 
                         this.EntradaCotizacion.DataType = Lui.Forms.DataTypes.Currency;
-                        this.EntradaCotizacion.Location = new System.Drawing.Point(143, 61);
+                        this.EntradaCotizacion.Location = new System.Drawing.Point(151, 48);
                         this.EntradaCotizacion.Name = "EntradaCotizacion";
                         this.EntradaCotizacion.Prefijo = "$";
                         this.EntradaCotizacion.Size = new System.Drawing.Size(172, 24);
@@ -55,17 +60,63 @@ namespace Lfc.Monedas
                         // 
                         // label1
                         // 
-                        this.label1.Location = new System.Drawing.Point(3, 61);
+                        this.label1.Location = new System.Drawing.Point(8, 48);
                         this.label1.Name = "label1";
                         this.label1.Size = new System.Drawing.Size(140, 24);
                         this.label1.TabIndex = 8;
                         this.label1.Text = "Cotización";
                         this.label1.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
                         // 
+                        // EntradaCodigoIso
+                        // 
+                        this.EntradaCodigoIso.Location = new System.Drawing.Point(151, 80);
+                        this.EntradaCodigoIso.Name = "EntradaCodigoIso";
+                        this.EntradaCodigoIso.Size = new System.Drawing.Size(172, 24);
+                        this.EntradaCodigoIso.TabIndex = 11;
+                        // 
+                        // label2
+                        // 
+                        this.label2.Location = new System.Drawing.Point(8, 80);
+                        this.label2.Name = "label2";
+                        this.label2.Size = new System.Drawing.Size(140, 24);
+                        this.label2.TabIndex = 10;
+                        this.label2.Text = "Codigo ISO";
+                        this.label2.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+                        // 
+                        // EntradaSigno
+                        // 
+                        this.EntradaSigno.Location = new System.Drawing.Point(151, 112);
+                        this.EntradaSigno.Name = "EntradaSigno";
+                        this.EntradaSigno.Size = new System.Drawing.Size(172, 24);
+                        this.EntradaSigno.TabIndex = 13;
+                        // 
+                        // label4
+                        // 
+                        this.label4.Location = new System.Drawing.Point(8, 112);
+                        this.label4.Name = "label4";
+                        this.label4.Size = new System.Drawing.Size(140, 24);
+                        this.label4.TabIndex = 12;
+                        this.label4.Text = "Simbolo";
+                        this.label4.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+                        // 
+                        // LabelFechaValor
+                        // 
+                        this.LabelFechaValor.Location = new System.Drawing.Point(8, 160);
+                        this.LabelFechaValor.Name = "LabelFechaValor";
+                        this.LabelFechaValor.Size = new System.Drawing.Size(560, 24);
+                        this.LabelFechaValor.TabIndex = 14;
+                        this.LabelFechaValor.Text = "Text Text Text Text Text ";
+                        this.LabelFechaValor.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+                        // 
                         // Editar
                         // 
                         this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
                         this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
+                        this.Controls.Add(this.LabelFechaValor);
+                        this.Controls.Add(this.EntradaSigno);
+                        this.Controls.Add(this.label4);
+                        this.Controls.Add(this.EntradaCodigoIso);
+                        this.Controls.Add(this.label2);
                         this.Controls.Add(this.EntradaCotizacion);
                         this.Controls.Add(this.label1);
                         this.Controls.Add(this.EntradaNombre);
@@ -82,5 +133,10 @@ namespace Lfc.Monedas
                 internal Lui.Forms.Label Label3;
                 internal Lui.Forms.TextBox EntradaCotizacion;
                 internal Lui.Forms.Label label1;
+                internal Lui.Forms.TextBox EntradaCodigoIso;
+                internal Lui.Forms.Label label2;
+                internal Lui.Forms.TextBox EntradaSigno;
+                internal Lui.Forms.Label label4;
+                internal Lui.Forms.Label LabelFechaValor;
         }
 }

--- a/Lfc/Monedas/Editar.cs
+++ b/Lfc/Monedas/Editar.cs
@@ -20,8 +20,14 @@ namespace Lfc.Monedas
                 public override void ActualizarControl()
                 {
                         Lbl.Entidades.Moneda Res = this.Elemento as Lbl.Entidades.Moneda;
-
-                        EntradaCotizacion.ValueDecimal = Res.Cotizacion;                       
+                        EntradaNombre.Text = Res.Nombre;
+                        EntradaCotizacion.ValueDecimal = Res.Cotizacion;
+                        EntradaCodigoIso.Text = Res.NomenclaturaIso;
+                        EntradaSigno.Text = Res.Simbolo;
+                        if (Res.Fecha != null)
+                                LabelFechaValor.Text = "La última fecha de modificación registrada es del: " + Res.Fecha;
+                        else
+                                LabelFechaValor.Text = "";
 
                         base.ActualizarControl();
                 }
@@ -31,8 +37,11 @@ namespace Lfc.Monedas
                       
 
                         if (EntradaCotizacion.ValueDecimal<0)
-                              return new Lfx.Types.FailureOperationResult("La catización debe ser mayor a 0");                       
-
+                              return new Lfx.Types.FailureOperationResult("La catización debe ser mayor a 0");
+                        if ((EntradaCodigoIso.Text.Length > 3) || (EntradaCodigoIso.Text.Length < 1))
+                                return new Lfx.Types.FailureOperationResult("El Código ISO debe ser de tres letras máximo");
+                        if ((EntradaSigno.Text.Length > 3) || (EntradaSigno.Text.Length < 1))
+                                return new Lfx.Types.FailureOperationResult("El símbolo de la moneda debe ser de tres caracteres máximo");
                         return base.ValidarControl();
                 }
 
@@ -41,8 +50,10 @@ namespace Lfc.Monedas
                         Lbl.Entidades.Moneda Res = this.Elemento as Lbl.Entidades.Moneda;
 
 
-                        Res.Cotizacion = EntradaCotizacion.ValueDecimal;                       
-
+                        Res.Cotizacion = EntradaCotizacion.ValueDecimal;
+                        Res.Nombre = EntradaNombre.Text;
+                        Res.NomenclaturaIso = EntradaCodigoIso.Text;
+                        Res.Simbolo = EntradaSigno.Text;
                         base.ActualizarElemento();
                 }
         }

--- a/Lfc/Monedas/Editar.cs
+++ b/Lfc/Monedas/Editar.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Drawing;
+using System.Text;
+using System.Windows.Forms;
+
+namespace Lfc.Monedas
+{
+        public partial class Editar : Lcc.Edicion.ControlEdicion
+        {
+                public Editar()
+                {
+                        ElementoTipo = typeof(Lbl.Entidades.Moneda);
+
+                        InitializeComponent();
+                }
+
+                public override void ActualizarControl()
+                {
+                        Lbl.Entidades.Moneda Res = this.Elemento as Lbl.Entidades.Moneda;
+
+                        EntradaCotizacion.ValueDecimal = Res.Cotizacion;                       
+
+                        base.ActualizarControl();
+                }
+
+                public override Lfx.Types.OperationResult ValidarControl()
+                {
+                      
+
+                        if (EntradaCotizacion.ValueDecimal<0)
+                              return new Lfx.Types.FailureOperationResult("La catización debe ser mayor a 0");                       
+
+                        return base.ValidarControl();
+                }
+
+                public override void ActualizarElemento()
+                {
+                        Lbl.Entidades.Moneda Res = this.Elemento as Lbl.Entidades.Moneda;
+
+
+                        Res.Cotizacion = EntradaCotizacion.ValueDecimal;                       
+
+                        base.ActualizarElemento();
+                }
+        }
+}

--- a/Lfc/Monedas/Inicio.cs
+++ b/Lfc/Monedas/Inicio.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Collections.Generic;
+
+namespace Lfc.Monedas
+{
+        public class Inicio : Lazaro.Pres.Listings.Listing
+        {
+                public Inicio()
+                {
+                        ElementoTipo = typeof(Lbl.Entidades.Moneda);
+
+                        TableName = "monedas";
+                        KeyColumn = new Lazaro.Pres.Field("monedas.id_moneda", "Cód.", Lfx.Data.InputFieldTypes.Serial, 0);
+                        Columns = new Lazaro.Pres.FieldCollection() 
+			{
+				new Lazaro.Pres.Field("monedas.nombre", "Nombre", Lfx.Data.InputFieldTypes.Text, 320),
+                                new Lazaro.Pres.Field("monedas.signo", "Signo", Lfx.Data.InputFieldTypes.Text, 70),
+                                new Lazaro.Pres.Field("monedas.iso", "Cod. ISO", Lfx.Data.InputFieldTypes.Text, 80),
+                                new Lazaro.Pres.Field("monedas.cotizacion", "Cotizacion", Lfx.Data.InputFieldTypes.Currency, 100)
+			};
+                        OrderBy = "monedas.nombre";
+                }
+        }
+}

--- a/Lfc/Reportes/Patrimonio.cs
+++ b/Lfc/Reportes/Patrimonio.cs
@@ -40,7 +40,7 @@ namespace Lfc.Reportes
                         EntradaActivosCajas.Text = Lfx.Types.Formatting.FormatCurrency(ActivosCajas, Lfx.Workspace.Master.CurrentConfig.Moneda.Decimales);
                         EntradaPasivosCajas.Text = Lfx.Types.Formatting.FormatCurrency(PasivosCajas, Lfx.Workspace.Master.CurrentConfig.Moneda.Decimales);
 
-                        decimal ActivosStock = Connection.FieldDecimal("SELECT SUM(costo*stock_actual) FROM articulos WHERE costo>0 AND stock_actual>0");
+                        decimal ActivosStock = Connection.FieldDecimal("SELECT SUM(IFNULL(monedas.cotizacion, 1)*costo*stock_actual) FROM articulos JOIN monedas ON monedas.id_moneda=articulos.id_moneda WHERE costo>0 AND stock_actual>0");
                         EntradaActivosStock.Text = Lfx.Types.Formatting.FormatCurrency(ActivosStock, Lfx.Workspace.Master.CurrentConfig.Moneda.Decimales);
 
                         decimal Activos = ActivosCajas + ActivosStock;
@@ -63,7 +63,7 @@ namespace Lfc.Reportes
                         decimal PasivosCheques = Connection.FieldDecimal("SELECT SUM(importe) FROM bancos_cheques WHERE emitido>0 AND estado=0");
                         EntradaPasivosCheques.Text = Lfx.Types.Formatting.FormatCurrency(PasivosCheques, Lfx.Workspace.Master.CurrentConfig.Moneda.Decimales);
 
-                        decimal PasivosStock = Math.Abs(Connection.FieldDecimal("SELECT SUM(costo*stock_actual) FROM articulos WHERE costo>0 AND stock_actual<0"));
+                        decimal PasivosStock = Math.Abs(Connection.FieldDecimal("SELECT SUM(IFNULL(monedas.cotizacion, 1)*costo*stock_actual) FROM articulos JOIN monedas ON monedas.id_moneda=articulos.id_moneda WHERE costo>0 AND stock_actual<0"));
                         EntradaPasivosStock.Text = Lfx.Types.Formatting.FormatCurrency(PasivosStock, Lfx.Workspace.Master.CurrentConfig.Moneda.Decimales);
 
                         decimal Pasivos = PasivosCajas + PasivosCheques + PasivosStock;

--- a/Lfx/Data/Struct/dbstruct.xml
+++ b/Lfx/Data/Struct/dbstruct.xml
@@ -21,6 +21,7 @@
     <Column name="codigo4" datatype="VarChar" nullable="1" lenght="50" />
     <Column name="id_marca" inputtype="Relation" nullable="1" />
     <Column name="id_caja" inputtype="Relation" nullable="1" />
+    <Column name="id_moneda" inputtype="Relation" nullable="1"/>
     <Column name="modelo" datatype="VarChar" nullable="1" lenght="200" />
     <Column name="serie" datatype="VarChar" nullable="1" lenght="200" />
     <Column name="nombre" inputtype="Text" nullable="0" lenght="200" />
@@ -52,6 +53,7 @@
     <Index table="articulos" name="articulos_id_categoria" columns="id_categoria" unique="0" primary="0" />
     <Index table="articulos" name="articulos_id_marca" columns="id_marca" unique="0" primary="0" />
     <Index table="articulos" name="articulos_id_caja" columns="id_caja" unique="0" primary="0" />
+    <Index table="articulos" name="articulos_id_moneda" columns="id_moneda" unique="0" primary="0" />
     <Index table="articulos" name="articulos_id_margen" columns="id_margen" unique="0" primary="0" />
     <Index table="articulos" name="articulos_id_proveedor" columns="id_proveedor" unique="0" primary="0" />
     <Index table="articulos" name="PRIMARY" columns="id_articulo" unique="1" primary="1" />
@@ -61,6 +63,7 @@
   <Constraint name="fk_articulos_id_marca" table="articulos" column="id_marca" reference_table="marcas" reference_column="id_marca" />
   <Constraint name="fk_articulos_id_caja" table="articulos" column="id_caja" reference_table="cajas" reference_column="id_caja" />
   <Constraint name="fk_articulos_id_margen" table="articulos" column="id_margen" reference_table="margenes" reference_column="id_margen" />
+  <Constraint name="fk_articulos_id_moneda" table="articulos" column="id_moneda" reference_table="monedas" reference_column="id_moneda" />
 
 
   <Table name="articulos_categorias" lsdet="1" label="Categorías de Artículos">

--- a/Sistema/Principal/menu.xml
+++ b/Sistema/Principal/menu.xml
@@ -149,6 +149,7 @@
       <Opcion Nombre="Planes de cobro y pago" Funcion="LISTAR Lbl.Pagos.Plan" />
       <Opcion Nombre="-" Funcion="" />
       <Opcion Nombre="&amp;Localidades" Funcion="LISTAR Lbl.Entidades.Localidad" />
+      <Opcion Nombre="&amp;Monedas" Funcion="LISTAR Lbl.Entidades.Moneda" />
     </Opcion>
   </Opcion>
 </Menu>


### PR DESCRIPTION
Si bien el articulo esta cotizado en una moneda extranjera, en el listado de artículos y a la hora de agregar uno a un comprobante el valor del mismo se calcula automáticamente a su valor local (por medio de la configuración de localidad en preferencias), de no estar configurado ese parámetro se asume que la moneda local va a ser el peso Argentino.
Cuando editamos un articulo en el caso de que id_moneda== null fuerzo la asignación  de una moneda. 
TODO: Editar e Inicio de monedas 